### PR TITLE
Redis 쿼리 최적화(RTT 최소화, 원자적 연산), 컨테이너 보안 조치

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,11 @@ FROM gradle:8.14.2-jdk21 AS build
 
 WORKDIR /app
 
-COPY gradlew .
-COPY gradle ./gradle
 COPY build.gradle .
 COPY settings.gradle .
 COPY src ./src
 
-RUN ./gradlew build -x test --no-daemon
+RUN gradle build -x test --no-daemon
 
 FROM amazoncorretto:21.0.7-alpine3.19
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,14 @@ FROM amazoncorretto:21.0.7-alpine3.19
 
 WORKDIR /app
 
+ARG ID=1001
+RUN addgroup --gid ${ID} javauser && \
+    adduser --uid ${ID} --ingroup javauser --no-create-home --disabled-password javauser
+
 COPY --from=build /app/build/libs/*.jar /app.jar
 
 EXPOSE 8081
+
+USER javauser
 
 ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "/app.jar"]

--- a/src/main/java/cowing/project/cowingmsaorderbook/ws/OrderbookService.java
+++ b/src/main/java/cowing/project/cowingmsaorderbook/ws/OrderbookService.java
@@ -3,16 +3,11 @@ package cowing.project.cowingmsaorderbook.ws;
 import cowing.project.cowingmsaorderbook.dto.OrderbookDto;
 import cowing.project.cowingmsaorderbook.dto.OrderbookUnit;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.DefaultTypedTuple;
-import org.springframework.data.redis.core.RedisCallback;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.*;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -26,19 +21,24 @@ public class OrderbookService {
         String bidsKey = "orderbook:" + code + ":bids";
         String metaKey = "orderbook:" + code + ":meta";
 
+        String tempSuffix = String.valueOf(System.nanoTime());
+        String tempAsksKey = asksKey + ":" + tempSuffix;
+        String tempBidsKey = bidsKey + ":" + tempSuffix;
+        String tempMetaKey = metaKey + ":" + tempSuffix;
+
         // 1. 사전 데이터 준비: 루프 내에서 Redis 호출 제거
         Set<ZSetOperations.TypedTuple<String>> askTuples = new HashSet<>();
         Set<ZSetOperations.TypedTuple<String>> bidTuples = new HashSet<>();
-        
+
         // 배치 처리를 위한 데이터 준비
         for (OrderbookUnit unit : orderbookDto.orderbookUnits()) {
             askTuples.add(new DefaultTypedTuple<>(
-                unit.askSize().toPlainString(), 
-                unit.askPrice().doubleValue()
+                    unit.askSize().toPlainString(),
+                    unit.askPrice().doubleValue()
             ));
             bidTuples.add(new DefaultTypedTuple<>(
-                unit.bidSize().toPlainString(), 
-                unit.bidPrice().doubleValue()
+                    unit.bidSize().toPlainString(),
+                    unit.bidPrice().doubleValue()
             ));
         }
 
@@ -48,27 +48,28 @@ public class OrderbookService {
         metaData.put("total_ask_size", orderbookDto.totalAskSize().toPlainString());
         metaData.put("total_bid_size", orderbookDto.totalBidSize().toPlainString());
 
-        // 2. 파이프라이닝 사용: 트랜잭션 오버헤드 제거, 네트워크 라운드트립 최소화
-        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
-            // 기존 데이터 삭제
-            connection.del(asksKey.getBytes());
-            connection.del(bidsKey.getBytes());
-            connection.del(metaKey.getBytes());
-            
-            // 3. 배치 처리: 한 번에 모든 데이터 처리
-            if (!askTuples.isEmpty()) {
-                redisTemplate.opsForZSet().add(asksKey, askTuples);
+        // 2. 원자적 트랜잭션, 네트워크 라운드트립 최소화
+        redisTemplate.execute(new SessionCallback<List<Object>>() {
+            @Override
+            public List<Object> execute(RedisOperations operations) throws DataAccessException {
+                operations.multi(); // 트랜잭션 시작
+
+                // 모든 데이터를 임시키에 저장
+                if (!askTuples.isEmpty()) {
+                    operations.opsForZSet().add(tempAsksKey, askTuples);
+                }
+                if (!bidTuples.isEmpty()) {
+                    operations.opsForZSet().add(tempBidsKey, bidTuples);
+                }
+                operations.opsForHash().putAll(tempMetaKey, metaData);
+
+                // 원자적 변경 (덮어쓰기)
+                operations.rename(tempAsksKey, asksKey);
+                operations.rename(tempBidsKey, bidsKey);
+                operations.rename(tempMetaKey, metaKey);
+
+                return operations.exec(); // 트랜잭션 실행
             }
-            if (!bidTuples.isEmpty()) {
-                redisTemplate.opsForZSet().add(bidsKey, bidTuples);
-            }
-            
-            // 메타데이터 배치 업데이트
-            if (!metaData.isEmpty()) {
-                redisTemplate.opsForHash().putAll(metaKey, metaData);
-            }
-            
-            return null; // 파이프라인에서는 null 반환
         });
     }
 }

--- a/src/main/java/cowing/project/cowingmsaorderbook/ws/WebSocketHandler.java
+++ b/src/main/java/cowing/project/cowingmsaorderbook/ws/WebSocketHandler.java
@@ -13,12 +13,8 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.BinaryWebSocketHandler;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor


### PR DESCRIPTION
# 📝작업 내용
기존 방식은 아주 짧은 시간 동안 다른 클라이언트가 키를 조회하면 데이터가 없는 것처럼 보인다. pipelining 자체는 모든 요청을 묶어주지만 원자성을 보장하진 않는다.
```
삭제 -> 조회(일시적 키 없음) -> 삽입
```
따라서 **호가 갱신**에 맞게 값을 교체하는 방식으로 진행하였다.

이렇게 한다면 재환님이 진행하신 "배치 처리와 RTT 최소화"라는 이점에 더해 원자성을 보장할 수 있다.

또한, 해당 서비스의 역할은 "실시간 호가 갱신"이다. 타 서비스와 같이 소스 코드 수정이 잦지 않기 때문에 Layered Jar를 적용할 필요가 없다고 생각되어 컨테이너 이미지 관련한 보안 조치만 추가하였다.

# #️⃣연관된 이슈
#9 